### PR TITLE
Removed padding-top causing black bar at the top

### DIFF
--- a/src/youtube/widget/ui/youtube.css
+++ b/src/youtube/widget/ui/youtube.css
@@ -1,7 +1,8 @@
 .youtube {
     position: relative;
     padding-bottom: 56.25%;
-    padding-top: 30px; height: 0; overflow: hidden;
+    height: 0;
+    overflow: hidden;
 }
  
 .youtube iframe,


### PR DESCRIPTION
Fixed issue with a black bar at the top of the youtube video that also made the controls drop out of the viewer.
